### PR TITLE
Fixing support for Stylistic Set names

### DIFF
--- a/Lib/compositor/__init__.py
+++ b/Lib/compositor/__init__.py
@@ -38,9 +38,9 @@ class Font(object):
         else:
             self.source = TTFont(path)
         self.loadGlyphSet()
-        self.loadInfo()
         self.loadCMAP()
         self.loadFeatures()
+        self.loadInfo()
         if glyphClass is None:
             glyphClass = Glyph
         self.glyphClass = glyphClass
@@ -102,13 +102,14 @@ class Font(object):
         self.info.styleName = styleName
         # stylistic set names
         self.stylisticSetNames = {}
-        for i in range(20):
-            ssNameID = 256 + i
-            ssTag = "ss%02i" % (i + 1)
-            namePriority = [(ssNameID, 1, 0, 0), (ssNameID, 1, None, None), (ssNameID, 3, 1, 1033), (ssNameID, 3, None, None)]
-            ssName = self._skimNameIDs(nameIDs, namePriority)
-            if ssName:
-                self.stylisticSetNames[ssTag] = ssName
+        for featureRecord in self.gsub.FeatureList.FeatureRecord:
+            params = featureRecord.Feature.FeatureParams
+            if hasattr(params, "UINameID"):
+                ssNameID = params.UINameID
+                namePriority = [(ssNameID, 1, 0, 0), (ssNameID, 1, None, None), (ssNameID, 3, 1, 1033), (ssNameID, 3, None, None)]
+                ssName = self._skimNameIDs(nameIDs, namePriority)
+                if ssName:
+                    self.stylisticSetNames[featureRecord.FeatureTag] = ssName
 
     def _skimNameIDs(self, nameIDs, priority):
         for (nameID, platformID, platEncID, langID) in priority:


### PR DESCRIPTION
When I added this feature to Compositor I had misinterpreted how Stylistic Set names are arranged in the <name> table — Stylistic Set names are not sequential starting from ID 256, the names are instead arranged to match the order of the features (i.e. Stylistic Set 4 could be the first Stylistic Set in the font’s features and would be named at ID 256, Stylistic Set 10 could be the second feature at ID 257, etc.)

The correct Name ID for each Stylistic Set is compiled into the <GSUB> table as a parameter of the Stylistic Set’s FeatureRecord:

    font = TTFont(fontPath)
    gsub = font[“GSUB"]
    for featureRecord in gsub.table.FeatureList.FeatureRecord:
        params = featureRecord.Feature.FeatureParams
            if hasattr(params, "UINameID"):
            print featureRecord.FeatureTag, params.UINameID

There is support for calling a feature’s UINameID parameter in [Behdad Esfahbod’s fork of FontTools](http://github.com/behdad/fonttools/), but not in [the version on SourceForge](http://sourceforge.net/projects/fonttools/) (and this patch is built to not cause an error with the SourceForge version).

The table loading order in the Compositor font had to change to make this work, loadCMAP() and loadFeatures() had to come before loadInfo() so that the GSUB table would already be loaded by the time the names were unpacked. I don’t believe it looks like this will cause any problem, however.