### PR TITLE
Checking to see if there is a gsub table before collecting stylistic set names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.pyc

--- a/Lib/compositor/__init__.py
+++ b/Lib/compositor/__init__.py
@@ -102,14 +102,15 @@ class Font(object):
         self.info.styleName = styleName
         # stylistic set names
         self.stylisticSetNames = {}
-        for featureRecord in self.gsub.FeatureList.FeatureRecord:
-            params = featureRecord.Feature.FeatureParams
-            if hasattr(params, "UINameID"):
-                ssNameID = params.UINameID
-                namePriority = [(ssNameID, 1, 0, 0), (ssNameID, 1, None, None), (ssNameID, 3, 1, 1033), (ssNameID, 3, None, None)]
-                ssName = self._skimNameIDs(nameIDs, namePriority)
-                if ssName:
-                    self.stylisticSetNames[featureRecord.FeatureTag] = ssName
+        if self.gsub:
+            for featureRecord in self.gsub.FeatureList.FeatureRecord:
+                params = featureRecord.Feature.FeatureParams
+                if hasattr(params, "UINameID"):
+                    ssNameID = params.UINameID
+                    namePriority = [(ssNameID, 1, 0, 0), (ssNameID, 1, None, None), (ssNameID, 3, 1, 1033), (ssNameID, 3, None, None)]
+                    ssName = self._skimNameIDs(nameIDs, namePriority)
+                    if ssName:
+                        self.stylisticSetNames[featureRecord.FeatureTag] = ssName
 
     def _skimNameIDs(self, nameIDs, priority):
         for (nameID, platformID, platEncID, langID) in priority:


### PR DESCRIPTION
The feature list and Stylistic Set names should only be collected if there was a gsub table. Fixing a bug from a previous commit.