### PR TITLE
Try a number of cmap subtables to find the best option.

### DIFF
--- a/Lib/compositor/cmap.py
+++ b/Lib/compositor/cmap.py
@@ -4,16 +4,12 @@ and character mapping in general.
 """
 
 def extractCMAP(ttFont):
-    cmap = {}
-    cmapIDs = [(3, 10), (0, 3), (3, 1)]
-    for i in range(len(cmapIDs)):
-        if ttFont["cmap"].getcmap(*cmapIDs[i]):
-            cmap = ttFont["cmap"].getcmap(*cmapIDs[i]).cmap
-            break
-    if not cmap:
-        from compositor.error import CompositorError
-        raise CompositorError("Found neither CMAP (3, 10), (0, 3), nor (3, 1) in font.")
-    return cmap
+    for platformID, encodingID in [(3, 10), (0, 3), (3, 1)]:
+        cmapSubtable = ttFont["cmap"].getcmap(platformID, encodingID)
+        if cmapSubtable is not None:
+            return cmapSubtable.cmap
+    from compositor.error import CompositorError
+    raise CompositorError("Found neither CMAP (3, 10), (0, 3), nor (3, 1) in font.")
 
 def reverseCMAP(cmap):
     reversed = {}

--- a/Lib/compositor/cmap.py
+++ b/Lib/compositor/cmap.py
@@ -4,7 +4,15 @@ and character mapping in general.
 """
 
 def extractCMAP(ttFont):
-    return ttFont["cmap"].getcmap(3, 1).cmap
+    cmap = {}
+    cmapIDs = [(3, 10), (0, 3), (3, 1)]
+    for i in range(len(cmapIDs)):
+        if ttFont["cmap"].getcmap(*cmapIDs[i]):
+            cmap = ttFont["cmap"].getcmap(*cmapIDs[i]).cmap
+            break
+    if not cmap:
+        raise AttributeError("Found neither CMAP (3, 10), (0, 3), nor (3, 1) in font.")
+    return cmap
 
 def reverseCMAP(cmap):
     reversed = {}

--- a/Lib/compositor/cmap.py
+++ b/Lib/compositor/cmap.py
@@ -11,7 +11,8 @@ def extractCMAP(ttFont):
             cmap = ttFont["cmap"].getcmap(*cmapIDs[i]).cmap
             break
     if not cmap:
-        raise AttributeError("Found neither CMAP (3, 10), (0, 3), nor (3, 1) in font.")
+        from compositor.error import CompositorError
+        raise CompositorError("Found neither CMAP (3, 10), (0, 3), nor (3, 1) in font.")
     return cmap
 
 def reverseCMAP(cmap):


### PR DESCRIPTION
Compositor only looked for a (3, 1) cmap subtable, which will miss any non-BMP Unicode characters present in the font.

This patch checks for the presence of the cmap subtables (3, 10), (0, 3) and (3, 1) and returns the first match.